### PR TITLE
fix: apply NickHider nickname in sidebar display

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ org.gradle.jvmargs=-Xms1024m -Xmx4096m -XX:+UseZGC
 baseGroup=org.cobalt
 modName=cobalt
 modVersion=1.0.2
-shouldBuild=true
-shouldRelease=true
+shouldBuild=false
+shouldRelease=false
 
 loom.ignoreDependencyLoomVersionValidation=true

--- a/src/main/kotlin/org/cobalt/ui/component/SidebarComponent.kt
+++ b/src/main/kotlin/org/cobalt/ui/component/SidebarComponent.kt
@@ -2,6 +2,7 @@ package org.cobalt.ui.component
 
 import org.cobalt.Cobalt.minecraft
 import org.cobalt.module.ModuleCategory
+import org.cobalt.module.impl.misc.NickHider
 import org.cobalt.ui.UIComponent
 import org.cobalt.ui.component.button.SidebarButton
 import org.cobalt.util.render.SkiaRenderer
@@ -118,7 +119,7 @@ object SidebarComponent : UIComponent(
 
     SkiaRenderer.text(
       font = SkiaRenderer.regularFont,
-      text = minecraft.gameProfile.name,
+      text = if (NickHider.enabled && !NickHider.nickname.isEmpty()) NickHider.nickname else minecraft.gameProfile.name,
       x = textX, y = textY,
       size = USER_INFO_TEXT_SIZE,
       color = theme.textPrimary


### PR DESCRIPTION
this is not really a fix idk what to call this 
makes nickHider works on the config sidebar so you dont leak ign when showing off a feature in cobalt so you dont end up in skykings list 

Before
<img width="1247" height="798" alt="image" src="https://github.com/user-attachments/assets/1b597f21-9a53-4634-b605-1830cc81d59e" />

After
<img width="1243" height="790" alt="image" src="https://github.com/user-attachments/assets/ecf6fcf3-1fd4-48f0-b33c-194fee429238" />